### PR TITLE
chore(gradle): Merge `jar` task configuration in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,8 +130,10 @@ tasks {
         attrs["Build-Gradle"] = project.gradle.gradleVersion
         attrs["Build-OS"] = System.getProperty("os.name")
         attrs["Build-CI"] = System.getProperty("CI", "false")
+        attrs["Build-Automatic"] = System.getProperty("CI", "false")
         attrs["Version"] = version.toString()
         manifest.attributes(attrs)
+        exclude("**/*.RSA", "**/*.SF", "**/*.DSA", "**/amazon-*.properties")
     }
 
     named<Task>("build") {
@@ -202,19 +204,6 @@ tasks {
 
     named<Task>("check") {
         dependsOn(named("it-s3"))
-    }
-
-    named<Jar>("jar") {
-        val attrs = HashMap<String, String?>()
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz")
-        sdf.timeZone = TimeZone.getTimeZone("UTC")
-        attrs["Build-Date"] = sdf.format(Date())
-        attrs["Build-JDK"] = System.getProperty("java.version")
-        attrs["Build-Gradle"] = project.gradle.gradleVersion
-        attrs["Build-OS"] = System.getProperty("os.name")
-        attrs["Build-Automatic"] = System.getProperty("CI", "false")
-        manifest.attributes(attrs)
-        exclude("**/*.RSA", "**/*.SF", "**/*.DSA", "**/amazon-*.properties")
     }
 
     withType<Sign> {


### PR DESCRIPTION
# Pull Request Description

This pull request merges the two configurations of the `jar` gradle task in `build.gradle.kts`.

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
